### PR TITLE
fix #7, tested

### DIFF
--- a/shell_script/backup_sd.sh
+++ b/shell_script/backup_sd.sh
@@ -1,14 +1,11 @@
 #!/bin/bash
 # get the image from the raspberry pi into a zip in path specified by calling argument
 # zip name will be the hour:minute_month-date_rpi3_im.gz
-# $1 is path to output file(/home/kd/image_file) and $2 is the path to device as a whole (/dev/sdx)
+# $1 is path to output file(/home/kd/image_dir) and $2 is the path to device as a whole (/dev/sdx)
 # reference: https://raspberrypi.stackexchange.com/questions/311/how-do-i-backup-my-raspberry-pi
 source ./utils.sh
-set -e 
-set -o pipefail
-set -o nounset
-block_size=64K # generally recommended
 
+block_size=64K
 #-------------------------------------------------------------------
 
 # check arguments to see if they are actually folder and file descriptor to sd card
@@ -17,9 +14,9 @@ print_error "Given directory is not valid\n"
 exit 1
 
 else
-print_message "Copying image from SD card"
+print_message "Copying image from SD card at ${2} to ${1}, this can take a while"
 
-sudo dd if=$2 bs=${block_size} | gzip > $1/"$(date +'%H:%M_%m-%d')_rpi3_im.gz" # copy then compress
+sudo dd if=$2 bs=${block_size} | gzip > $1/"rpi3_im_$(date +'%H:%M_%b-%d').gz" # copy then compress
 print_message "SD card copied!"
 exit 0
 fi


### PR DESCRIPTION
Tested by rewriting the retrieved image, rpi boot fine
Change file name of backed up image for better clariy
Printed more info for easy confirmation before writing
The writing speed is 38.5 Mb/s best at bs=64K, take some time, 45.4Mb/s w/o usb adapter